### PR TITLE
Add editorconfig for rendering

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
This will force GitHub to render all source code in the project without an ident size of 8.