### PR TITLE
create and document file to cause a pod to be disabled

### DIFF
--- a/test/README
+++ b/test/README
@@ -1,0 +1,9 @@
+disable.sh can be used to disable a pod.
+kubectl cp disable.sh pr-primary:/tmp
+kubectl exec -it pr-primary /tmp/disable.sh
+
+It works by changing the name of PG_VERSION to PG_VERSION.BAK
+postgreSQL will not start in that state.
+
+Then sending a TERM signal to postgres. This will cause the pod to 
+terminate and subsequent starts will fail.

--- a/test/disable.sh
+++ b/test/disable.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Copyright 2018 Crunchy Data Solutions, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+mv /pgdata/pr-primary/PG_VERSION /pgdata/pr-primary/PG_VERSION.BAK
+kill -TERM $(head -1 /pgdata/pr-primary/postmaster.pid)
+


### PR DESCRIPTION
This is to be used for testing watch. Instead of deleting a pod, this will cause a pod to not start again, causing repeated crashes