### PR TITLE
Update rhel base image references

### DIFF
--- a/rhel7/10/Dockerfile.watch.rhel7
+++ b/rhel7/10/Dockerfile.watch.rhel7
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.5/Dockerfile.watch.rhel7
+++ b/rhel7/9.5/Dockerfile.watch.rhel7
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 

--- a/rhel7/9.6/Dockerfile.watch.rhel7
+++ b/rhel7/9.6/Dockerfile.watch.rhel7
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/rhel
+FROM registry.access.redhat.com/rhel7
 
 MAINTAINER Crunchy Data <support@crunchydata.com>
 


### PR DESCRIPTION
It appears that a rhel7.5 base image has become available.
However, if you look at the documentation, Red Hat has modified their base image naming strategy.

The old naming convention image can be found here:
https://access.redhat.com/containers/?tab=overview#/registry.access.redhat.com/rhel
Unfortunately, this image seems to be capped at 7.4 in favor of a new base image:
https://access.redhat.com/containers/?tab=overview#/registry.access.redhat.com/rhel7
As you can see, this new image uses 7.5 as a default.

I do not believe this to be a breaking change, as it is a patch to the underlying container packages.