### PR TITLE
adding missing target-type param

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -88,6 +88,10 @@ below.
 	| CRUNCHY_WATCH_DATABASE
 	| postgres
 	| database to connect
+| --target-type
+        | CRUNCHY_WATCH_TARGET_TYPE
+        | pod
+        | Failover tatget type can be POD or Deployment
 | --timeout
 	| CRUNCHY_WATCH_TIMEOUT
 	| 10s


### PR DESCRIPTION
CRUNCHY_WATCH_TARGET_TYPE is missing in the documentation 