### PR TITLE
Update RBAC, remove old README

### DIFF
--- a/examples/kube-deployments/README.txt
+++ b/examples/kube-deployments/README.txt
@@ -1,3 +1,0 @@
-this example assumes you are running the 
-master-replica-dc example in the crunchy container suite
-examples/openshift directory

--- a/examples/rbac.yaml
+++ b/examples/rbac.yaml
@@ -18,7 +18,7 @@ rules:
   verbs: ["*"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get", "list"]
+  verbs: ["get", "list", "update"]
 - apiGroups: [""]
   resources: ["pods/exec"]
   verbs: ["create"]


### PR DESCRIPTION
Missing an `update` rule for pods which caused errors on OpenShift.  Also removed a README that was very out of date (example doc in root directory README)

Closes CrunchyData/crunchy-containers-test#110